### PR TITLE
Stabilize Life OS HTML apps: safe storage, migrations, normalization, and Kanban WIP wiring

### DIFF
--- a/KanbanBoard.html
+++ b/KanbanBoard.html
@@ -810,6 +810,12 @@
           <p id="overdueMessage"></p>
         </div>
       </div>
+      <div style="display:flex;gap:12px;flex-wrap:wrap;margin:10px 0 16px;align-items:center;">
+        <strong>WIP limits:</strong>
+        <label>To Do <input type="number" id="limit-todo" min="0" placeholder="∞" style="width:88px"></label>
+        <label>Doing <input type="number" id="limit-doing" min="0" placeholder="∞" style="width:88px"></label>
+        <label>Done <input type="number" id="limit-done" min="0" placeholder="∞" style="width:88px"></label>
+      </div>
       <div class="kanban-board" id="kanbanBoard">
         <div class="kanban-column todo" data-status="todo">
           <h3><span class="column-title">To Do</span><span class="task-count" id="count-todo">0</span></h3>
@@ -877,6 +883,15 @@
 
   <script>
     const STORAGE_KEYS = {
+      tasks: 'lifeos:kanban:tasks',
+      wip: 'lifeos:kanban:wipLimits',
+      filters: 'lifeos:kanban:filters',
+      focusCollapsed: 'lifeos:kanban:focusCollapsed',
+      focusSnoozeUntil: 'lifeos:kanban:focusSnoozeUntil',
+      localSnapshot: 'lifeos:kanban:localSnapshot'
+    };
+
+    const LEGACY_STORAGE_KEYS = {
       tasks: 'ownYourPrime.tasks',
       wip: 'ownYourPrime.wipLimits',
       filters: 'ownYourPrime.filters',
@@ -949,6 +964,36 @@
 
     if (elements.filterBtn) elements.filterBtn.setAttribute('aria-expanded', 'false');
 
+    function safeParseJSON(raw, fallback, keyForQuarantine = '') {
+      if (typeof raw !== 'string') return fallback;
+      try {
+        return JSON.parse(raw);
+      } catch (error) {
+        console.warn(`Storage parse failed for ${keyForQuarantine}`, error);
+        if (keyForQuarantine) {
+          const ts = Date.now();
+          localStorage.setItem(`${keyForQuarantine}__corrupt__${ts}`, raw);
+          localStorage.removeItem(keyForQuarantine);
+        }
+        return fallback;
+      }
+    }
+
+    function migrateStorageKeys() {
+      Object.entries(STORAGE_KEYS).forEach(([name, key]) => {
+        if (localStorage.getItem(key) !== null) return;
+        const legacyKey = LEGACY_STORAGE_KEYS[name];
+        const legacyRaw = legacyKey ? localStorage.getItem(legacyKey) : null;
+        if (!legacyRaw) return;
+        const parsed = safeParseJSON(legacyRaw, null, legacyKey);
+        if (parsed !== null) {
+          localStorage.setItem(key, JSON.stringify(parsed));
+        }
+      });
+    }
+
+    migrateStorageKeys();
+
     function saveToStorage(key, data) {
       try {
         localStorage.setItem(key, JSON.stringify(data));
@@ -958,13 +1003,8 @@
     }
 
     function loadFromStorage(key) {
-      try {
-        const raw = localStorage.getItem(key);
-        return raw ? JSON.parse(raw) : null;
-      } catch (error) {
-        console.warn('Storage load failed', error);
-        return null;
-      }
+      const raw = localStorage.getItem(key);
+      return raw ? safeParseJSON(raw, null, key) : null;
     }
 
     function removeFromStorage(key) {
@@ -1187,6 +1227,17 @@
       return normalized;
     }
 
+    function normalizeWipLimits(raw) {
+      const fallback = { todo: null, doing: null, done: null };
+      if (!raw || typeof raw !== 'object') return fallback;
+      const out = { ...fallback };
+      ['todo', 'doing', 'done'].forEach((status) => {
+        const n = Number(raw[status]);
+        out[status] = Number.isFinite(n) && n >= 0 ? n : null;
+      });
+      return out;
+    }
+
     function completedDaysAgo(task, now = new Date()) {
       if (!task.completedAt) return -1;
       const completed = new Date(task.completedAt);
@@ -1203,7 +1254,7 @@
     syncFilterMenuToState();
 
     let tasks = (loadFromStorage(STORAGE_KEYS.tasks) || []).map(normalizeTask);
-    let wipLimits = loadFromStorage(STORAGE_KEYS.wip) || { todo: null, doing: null, done: null };
+    let wipLimits = normalizeWipLimits(loadFromStorage(STORAGE_KEYS.wip));
     let editingTaskId = null;
     let historyStageIndex = 0;
     let focusCollapsed = loadFromStorage(STORAGE_KEYS.focusCollapsed);
@@ -1675,6 +1726,16 @@
       renderBoard();
     }
 
+    function showNonBlockingWarning(message) {
+      console.warn(message);
+      if (!elements.overdueMessage || !elements.overdueNotice) return;
+      elements.overdueNotice.style.display = 'block';
+      elements.overdueNotice.classList.remove('collapsed');
+      elements.overdueMessage.textContent = message;
+      clearTimeout(showNonBlockingWarning._timer);
+      showNonBlockingWarning._timer = setTimeout(() => updateOverdueNotice(new Date()), 2200);
+    }
+
     function deleteTask(taskId) {
       const task = tasks.find((t) => t.id === taskId);
       if (!task) return;
@@ -1724,7 +1785,22 @@
       if (Number.isNaN(targetLimit) || targetLimit < 0) return true;
       const currentDoing = tasks.filter((t) => t.status === 'doing' && t.id !== taskId).length;
       if (currentDoing >= targetLimit) {
-        alert(`Cannot move to DOING: WIP limit is ${targetLimit}.`);
+        showNonBlockingWarning(`Cannot move to DOING: WIP limit is ${targetLimit}.`);
+        return false;
+      }
+      return true;
+    }
+
+    function canEnterStatus(status, taskId = null) {
+      if (!['todo', 'doing', 'done'].includes(status)) return false;
+      if (status === 'doing') return canEnterDoing(taskId);
+      const limit = wipLimits[status];
+      if (limit === null || limit === undefined || limit === '') return true;
+      const targetLimit = Number(limit);
+      if (!Number.isFinite(targetLimit) || targetLimit < 0) return true;
+      const current = tasks.filter((t) => t.status === status && t.id !== taskId).length;
+      if (current >= targetLimit) {
+        showNonBlockingWarning(`Cannot move to ${status.toUpperCase()}: WIP limit is ${targetLimit}.`);
         return false;
       }
       return true;
@@ -1924,6 +2000,7 @@
           task.subtasks = subtasks;
         }
       } else {
+        if (!canEnterStatus('todo')) return;
         tasks.push(normalizeTask({
           id: generateId(),
           title,
@@ -1970,9 +2047,17 @@
       element.addEventListener('drop', (event) => {
         event.preventDefault();
         const taskId = event.dataTransfer.getData('text/plain');
+        if (!taskId) {
+          showNonBlockingWarning('Drop ignored: invalid task payload.');
+          return;
+        }
         const task = tasks.find((t) => t.id === taskId);
-        if (!task || task.status === status) return;
-        if (status === 'doing' && !canEnterDoing(taskId)) return;
+        if (!task) {
+          showNonBlockingWarning('Drop ignored: task not found.');
+          return;
+        }
+        if (task.status === status) return;
+        if (!canEnterStatus(status, taskId)) return;
         if (task.status === 'doing' && status !== 'doing' && task.startedAt) {
           task.timeSpent = (task.timeSpent || 0) + (Date.now() - task.startedAt);
           delete task.startedAt;
@@ -2106,7 +2191,7 @@
       }
       const sanitized = JSON.parse(JSON.stringify(snapshot));
       tasks = sanitized.tasks.map(normalizeTask);
-      wipLimits = sanitized.wipLimits || { todo: null, doing: null, done: null };
+      wipLimits = normalizeWipLimits(sanitized.wipLimits);
       Object.entries(wipLimits).forEach(([status, value]) => {
         const input = elements.limits[status];
         if (input) input.value = value ?? '';
@@ -2142,7 +2227,10 @@
       const reader = new FileReader();
       reader.onload = (event) => {
         try {
-          const parsed = JSON.parse(event.target.result);
+          const parsed = safeParseJSON(event.target.result, null);
+          if (!parsed) {
+            throw new Error('Invalid backup JSON.');
+          }
           applySnapshot(parsed);
           alert('Backup imported successfully.');
           closeBackupMenu();
@@ -2180,9 +2268,12 @@
       Object.entries(elements.limits).forEach(([status, input]) => {
         if (!input) return;
         input.addEventListener('change', () => {
-          const value = input.value;
-          wipLimits[status] = value === '' ? null : Number(value);
+          const value = input.value.trim();
+          const parsed = value === '' ? null : Number(value);
+          wipLimits[status] = Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+          input.value = wipLimits[status] ?? '';
           persistWipLimits();
+          renderBoard();
         });
       });
 

--- a/getyourshit_together.html
+++ b/getyourshit_together.html
@@ -1416,12 +1416,64 @@
     */
 
     // ===== UTILITY FUNCTIONS =====
-    function saveToStorage(key, data) {
-      localStorage.setItem(key, JSON.stringify(data));
+    const STORAGE_KEYS = {
+      meals: 'lifeos:gyst:meals',
+      presetMeals: 'lifeos:gyst:presetMeals',
+      profile: 'lifeos:gyst:profile',
+      targets: 'lifeos:gyst:targets',
+      weightHistory: 'lifeos:gyst:weightHistory',
+      tasks: 'lifeos:gyst:kanban:tasks',
+      wipLimits: 'lifeos:gyst:kanban:wipLimits',
+      habits: 'lifeos:gyst:habits'
+    };
+
+    function resolveStorageKey(key) {
+      return STORAGE_KEYS[key] || key;
     }
-    function loadFromStorage(key) {
-      const raw = localStorage.getItem(key);
-      return raw ? JSON.parse(raw) : null;
+
+    function safeParseJSON(raw, fallback, keyForQuarantine = '') {
+      if (typeof raw !== 'string') return fallback;
+      try {
+        return JSON.parse(raw);
+      } catch (error) {
+        console.warn(`Invalid JSON in storage key "${keyForQuarantine}"`, error);
+        if (keyForQuarantine) {
+          const ts = Date.now();
+          localStorage.setItem(`${keyForQuarantine}__corrupt__${ts}`, raw);
+          localStorage.removeItem(keyForQuarantine);
+        }
+        return fallback;
+      }
+    }
+
+    function safeGetStorage(key, fallback = null) {
+      const namespacedKey = resolveStorageKey(key);
+      const raw = localStorage.getItem(namespacedKey);
+      return raw ? safeParseJSON(raw, fallback, namespacedKey) : fallback;
+    }
+
+    function safeSetStorage(key, data) {
+      localStorage.setItem(resolveStorageKey(key), JSON.stringify(data));
+    }
+
+    function migrateStorageKeys() {
+      Object.entries(STORAGE_KEYS).forEach(([legacy, namespaced]) => {
+        if (localStorage.getItem(namespaced) !== null) return;
+        const legacyRaw = localStorage.getItem(legacy);
+        if (legacyRaw === null) return;
+        const parsed = safeParseJSON(legacyRaw, null, legacy);
+        if (parsed !== null) {
+          localStorage.setItem(namespaced, JSON.stringify(parsed));
+        }
+        localStorage.removeItem(legacy);
+      });
+    }
+
+    function saveToStorage(key, data) {
+      safeSetStorage(key, data);
+    }
+    function loadFromStorage(key, fallback = null) {
+      return safeGetStorage(key, fallback);
     }
     function generateId() {
       return Date.now().toString(36) + Math.random().toString(36).substr(2, 5);
@@ -1447,6 +1499,71 @@
       const d = String(date.getDate()).padStart(2, '0');
       return `${y}-${m}-${d}`;
     }
+
+    function normalizeMeal(meal) {
+      if (!meal || typeof meal !== 'object') return null;
+      const calories = Number(meal.calories);
+      const date = typeof meal.date === 'string' ? meal.date : '';
+      const name = typeof meal.name === 'string' ? meal.name.trim() : '';
+      if (!date || !name || Number.isNaN(calories)) return null;
+      return {
+        id: meal.id || generateId(),
+        date,
+        time: typeof meal.time === 'string' ? meal.time : '',
+        name,
+        ingredients: Array.isArray(meal.ingredients) ? meal.ingredients.map(i => String(i).trim()).filter(Boolean) : [],
+        calories: Math.max(0, Math.round(calories))
+      };
+    }
+
+    function normalizeTask(task) {
+      if (!task || typeof task !== 'object') return null;
+      const status = ['todo', 'doing', 'done'].includes(task.status) ? task.status : 'todo';
+      const title = typeof task.title === 'string' ? task.title.trim() : '';
+      if (!title) return null;
+      const assignedRaw = Array.isArray(task.assigned) ? task.assigned : [];
+      return {
+        id: task.id || generateId(),
+        title,
+        description: typeof task.description === 'string' ? task.description : '',
+        priority: ['low', 'medium', 'high', 'urgent'].includes(task.priority) ? task.priority : 'low',
+        assigned: assignedRaw.map(a => String(a).trim()).filter(Boolean),
+        status
+      };
+    }
+
+    function normalizeHabit(habit) {
+      if (!habit || typeof habit !== 'object') return null;
+      const name = typeof habit.name === 'string' ? habit.name.trim() : '';
+      if (!name) return null;
+      const history = {};
+      const rawHistory = habit.history && typeof habit.history === 'object' ? habit.history : {};
+      Object.entries(rawHistory).forEach(([date, state]) => {
+        if (typeof date !== 'string') return;
+        if (state === 'done' || state === 'skip' || state === 'none') {
+          history[date] = state;
+        }
+      });
+      return {
+        id: habit.id || generateId(),
+        name,
+        color: typeof habit.color === 'string' ? habit.color : '#6B5B95',
+        history
+      };
+    }
+
+    function normalizeWipLimits(value) {
+      const fallback = { todo: null, doing: 3, done: null };
+      if (!value || typeof value !== 'object') return fallback;
+      const out = { ...fallback };
+      ['todo', 'doing', 'done'].forEach((status) => {
+        const n = Number(value[status]);
+        out[status] = Number.isFinite(n) && n >= 0 ? n : null;
+      });
+      return out;
+    }
+
+    migrateStorageKeys();
 
     // ===== NAVIGATION HANDLING =====
     const navMealBtn = document.getElementById('navMeal');
@@ -1481,7 +1598,7 @@
     navSettingsBtn.addEventListener('click', () => showSection('settings'));
 
     // ===== MEAL TRACKER =====
-    let meals = loadFromStorage('meals') || [];
+    let meals = (loadFromStorage('meals', []) || []).map(normalizeMeal).filter(Boolean);
     // If there are no meals, set default example data for demonstration
     if (meals.length === 0) {
       const today = new Date();
@@ -1494,7 +1611,7 @@
       saveToStorage('meals', meals);
     }
 
-    let presetMeals = loadFromStorage('presetMeals');
+    let presetMeals = loadFromStorage('presetMeals', []);
     if (!Array.isArray(presetMeals) || presetMeals.length === 0) {
       presetMeals = [
         { id: generateId(), name: 'Protein oats', calories: 420, time: '07:30', ingredients: 'oats, whey, banana' },
@@ -1513,18 +1630,18 @@
       saveToStorage('presetMeals', presetMeals);
     }
 
-    let profile = loadFromStorage('profile') || {
+    let profile = loadFromStorage('profile', {
       age: 29,
       height: 175,
       weight: 72.5,
       lifestyle: 'moderate',
-    };
+    });
 
-    let targets = loadFromStorage('targets') || {
+    let targets = loadFromStorage('targets', {
       targetWeight: 68,
       goalType: 'loss',
       weeklyChange: -0.5,
-    };
+    });
     targets = {
       targetWeight: targets.targetWeight === '' || targets.targetWeight === null || targets.targetWeight === undefined
         ? ''
@@ -1533,7 +1650,7 @@
       weeklyChange: Number(targets.weeklyChange || 0),
     };
 
-    let weightHistory = loadFromStorage('weightHistory');
+    let weightHistory = loadFromStorage('weightHistory', []);
     if (!Array.isArray(weightHistory)) weightHistory = [];
     weightHistory = weightHistory.map(entry => ({
       date: entry.date,
@@ -2213,8 +2330,25 @@
       updateTargetProjection();
     }
 
+    function getDraftTargetsFromForm() {
+      const targetWeightValue = targetWeightInput.value;
+      const goalType = goalTypeSelect.value || 'maintain';
+      const parsedTargetWeight = targetWeightValue === '' ? '' : Number(targetWeightValue);
+      const baseWeekly = weeklyChangeInput.value === '' ? 0 : Number(weeklyChangeInput.value);
+      const weeklyAbs = Number.isFinite(baseWeekly) ? Math.min(Math.abs(baseWeekly), 5) : 0;
+      let weeklyChange = 0;
+      if (goalType === 'loss') weeklyChange = -weeklyAbs;
+      else if (goalType === 'gain') weeklyChange = weeklyAbs;
+      return {
+        targetWeight: parsedTargetWeight === '' || Number.isNaN(parsedTargetWeight) ? '' : parsedTargetWeight,
+        goalType,
+        weeklyChange
+      };
+    }
+
     function updateTargetProjection() {
-      const targetWeight = targets.targetWeight !== '' ? Number(targets.targetWeight) : null;
+      const draftTargets = getDraftTargetsFromForm();
+      const targetWeight = draftTargets.targetWeight !== '' ? Number(draftTargets.targetWeight) : null;
       if (!targetWeight) {
         targetProjection.textContent = 'Set your targets to unlock smart projections.';
         return;
@@ -2225,7 +2359,7 @@
         return;
       }
       const diff = targetWeight - currentWeight;
-      const weeklyChange = Number(targets.weeklyChange || 0);
+      const weeklyChange = Number(draftTargets.weeklyChange || 0);
       if (Math.abs(diff) < 0.1) {
         targetProjection.textContent = 'You are already sitting at your target weight – amazing work!';
         return;
@@ -2470,7 +2604,7 @@
     renderWeightCard();
 
     // ===== KANBAN BOARD =====
-    let tasks = loadFromStorage('tasks') || [];
+    let tasks = (loadFromStorage('tasks', []) || []).map(normalizeTask).filter(Boolean);
     if (tasks.length === 0) {
       // Demo tasks
       tasks = [
@@ -2481,7 +2615,7 @@
       saveToStorage('tasks', tasks);
     }
     // WIP limits: default values loaded from storage or defaults
-    let wipLimits = loadFromStorage('wipLimits') || { todo: null, doing: 3, done: null };
+    let wipLimits = normalizeWipLimits(loadFromStorage('wipLimits', { todo: null, doing: 3, done: null }));
     document.getElementById('limit-todo').value = wipLimits.todo ?? '';
     document.getElementById('limit-doing').value = wipLimits.doing ?? '';
     document.getElementById('limit-done').value = wipLimits.done ?? '';
@@ -2494,6 +2628,27 @@
     const cancelTaskBtn = document.getElementById('cancelTaskBtn');
 
     let editingTaskId = null;
+
+    const boardWarning = document.createElement('div');
+    boardWarning.className = 'callout';
+    boardWarning.style.display = 'none';
+    const kanbanSection = document.getElementById('kanbanSection');
+    if (kanbanSection) {
+      const board = kanbanSection.querySelector('.kanban-board');
+      if (board && board.parentNode) {
+        board.parentNode.insertBefore(boardWarning, board);
+      }
+    }
+
+    function showBoardWarning(message) {
+      if (!boardWarning) return;
+      boardWarning.textContent = message;
+      boardWarning.style.display = 'block';
+      clearTimeout(showBoardWarning._timer);
+      showBoardWarning._timer = setTimeout(() => {
+        boardWarning.style.display = 'none';
+      }, 2200);
+    }
 
     function renderBoard() {
       // Clear existing tasks
@@ -2555,16 +2710,24 @@
       element.addEventListener('drop', (ev) => {
         ev.preventDefault();
         const id = ev.dataTransfer.getData('text/plain');
+        if (!id) {
+          showBoardWarning('Drop ignored: invalid task payload.');
+          return;
+        }
+        const task = tasks.find(t => t.id === id);
+        if (!task) {
+          showBoardWarning('Drop ignored: task no longer exists.');
+          return;
+        }
         const targetStatus = status;
         const limit = wipLimits[targetStatus];
         if (limit !== null && limit !== undefined && limit !== '' && limit >= 0) {
           const currentCount = tasks.filter(t => t.status === targetStatus).length;
-          if (currentCount >= limit && tasks.find(t => t.id === id).status !== targetStatus) {
-            alert(`Cannot move: WIP limit for ${targetStatus.toUpperCase()} is ${limit}`);
+          if (currentCount >= limit && task.status !== targetStatus) {
+            showBoardWarning(`Cannot move: WIP limit for ${targetStatus.toUpperCase()} is ${limit}.`);
             return;
           }
         }
-        const task = tasks.find(t => t.id === id);
         if (task) {
           task.status = targetStatus;
           saveToStorage('tasks', tasks);
@@ -2588,8 +2751,10 @@
       input.addEventListener('change', () => {
         const status = inputId.split('-')[1];
         const value = input.value;
-        wipLimits[status] = value ? Number(value) : null;
+        const parsed = value === '' ? null : Number(value);
+        wipLimits[status] = Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
         saveToStorage('wipLimits', wipLimits);
+        renderBoard();
       });
     });
 
@@ -2638,7 +2803,7 @@
     renderBoard();
 
     // ===== HABIT TRACKER =====
-    let habits = loadFromStorage('habits') || [];
+    let habits = (loadFromStorage('habits', []) || []).map(normalizeHabit).filter(Boolean);
     if (habits.length === 0) {
       // Demo habits with example history for last few days
       const today = new Date();
@@ -2877,14 +3042,19 @@
       const reader = new FileReader();
       reader.onload = (evt) => {
         try {
-          const imported = JSON.parse(evt.target.result);
-          if (Array.isArray(imported)) {
-            habits = imported;
-            saveToStorage('habits', habits);
-            renderHabits();
-          } else {
-            alert('Invalid file format.');
+          const imported = safeParseJSON(evt.target.result, null);
+          if (!Array.isArray(imported)) {
+            alert('Invalid file format. Expected an array of habits.');
+            return;
           }
+          const normalized = imported.map(normalizeHabit).filter(Boolean);
+          if (!normalized.length && imported.length) {
+            alert('Import rejected: no valid habits found in file.');
+            return;
+          }
+          habits = normalized;
+          saveToStorage('habits', habits);
+          renderHabits();
         } catch (err) {
           alert('Failed to import habits: ' + err.message);
         }
@@ -2893,6 +3063,15 @@
       // Reset input so the same file can be uploaded again later
       importHabitsInput.value = '';
     });
+
+    window.lifeOsSelfTest = function lifeOsSelfTest() {
+      const report = [];
+      report.push({ check: 'meals normalized', pass: meals.every(m => m && m.id && m.name) });
+      report.push({ check: 'tasks normalized', pass: tasks.every(t => t && t.id && t.title && t.status) });
+      report.push({ check: 'habits normalized', pass: habits.every(h => h && h.id && h.name && h.history) });
+      console.table(report);
+      return report;
+    };
 
     renderHabits();
   </script>

--- a/habit-tracker-enhanced.html
+++ b/habit-tracker-enhanced.html
@@ -1028,8 +1028,9 @@
   <div id="toastContainer" style="position:fixed; bottom:24px; right:24px; display:flex; flex-direction:column; gap:10px; z-index:300;"></div>
   <script>
 (function() {
-  const STORAGE_KEY = 'habitTracker.v3';
+  const STORAGE_KEY = 'lifeos:habits:data';
   const LEGACY_KEY = 'habitTrackerData_v2';
+  const LEGACY_STORAGE_KEY = 'habitTracker.v3';
   const MARK_SEQUENCE = ['NONE', 'DONE', 'SKIP', 'MISS'];
   const DEFAULT_MISS_REASONS = ['Not logged', 'Lazy', 'Forgot', 'Work', 'Medical', 'Travel', 'Social'];
   const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -1039,6 +1040,7 @@
     { value: 90, message: '🏆 3-Month Lifestyle' }
   ];
 
+  migrateStorageKeys();
   let appState = loadAppState();
   let currentStartDate = getInitialRangeStart();
   let selectedDate = formatDate(new Date());
@@ -1247,14 +1249,41 @@
     return 'habit-' + Math.random().toString(36).slice(2, 10);
   }
 
+  function safeParseJSON(raw, fallback, keyForQuarantine = '') {
+    if (typeof raw !== 'string') return fallback;
+    try {
+      return JSON.parse(raw);
+    } catch (error) {
+      console.warn(`Invalid JSON in storage key "${keyForQuarantine}"`, error);
+      if (keyForQuarantine) {
+        const ts = Date.now();
+        localStorage.setItem(`${keyForQuarantine}__corrupt__${ts}`, raw);
+        localStorage.removeItem(keyForQuarantine);
+      }
+      return fallback;
+    }
+  }
+
+  function migrateStorageKeys() {
+    if (localStorage.getItem(STORAGE_KEY) === null) {
+      const oldRaw = localStorage.getItem(LEGACY_STORAGE_KEY);
+      if (oldRaw !== null) {
+        const parsed = safeParseJSON(oldRaw, null, LEGACY_STORAGE_KEY);
+        if (parsed) {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed));
+        }
+      }
+    }
+  }
+
   function loadAppState() {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
-      return normalizeState(JSON.parse(stored));
+      return normalizeState(safeParseJSON(stored, createDefaultState(), STORAGE_KEY));
     }
     const legacy = localStorage.getItem(LEGACY_KEY);
     if (legacy) {
-      const migrated = migrateLegacyData(JSON.parse(legacy));
+      const migrated = migrateLegacyData(safeParseJSON(legacy, {}, LEGACY_KEY));
       saveState(migrated);
       return migrated;
     }
@@ -1300,6 +1329,9 @@
   }
 
   function normalizeState(state) {
+    if (!state || typeof state !== 'object') {
+      return createDefaultState();
+    }
     state.settings = state.settings || {};
     if (!Array.isArray(state.settings.missReasons)) {
       state.settings.missReasons = DEFAULT_MISS_REASONS.slice();
@@ -1312,21 +1344,39 @@
     state.analyticsCache = state.analyticsCache || null;
     state.reminderState = state.reminderState || {};
     state.lastEndOfDayRun = state.lastEndOfDayRun || null;
-    state.habits = (state.habits || []).map(habit => {
-      habit.id = habit.id || generateId();
-      habit.color = habit.color || '#4dd0e1';
-      habit.notes = habit.notes || '';
-      habit.reminderEnabled = Boolean(habit.reminderEnabled);
-      habit.reminderTime = habit.reminderTime || null;
-      habit.reminderDays = Array.isArray(habit.reminderDays) ? habit.reminderDays : [];
-      habit.entries = habit.entries || {};
-      habit.currentStreak = habit.currentStreak || 0;
-      habit.bestStreak = habit.bestStreak || 0;
-      habit.lastCelebration = habit.lastCelebration || 0;
-      habit.created = habit.created || formatDate(new Date());
-      return habit;
-    });
+    state.habits = (Array.isArray(state.habits) ? state.habits : []).map(normalizeHabit).filter(Boolean);
     return state;
+  }
+
+  function normalizeHabit(habit) {
+    if (!habit || typeof habit !== 'object') return null;
+    const name = typeof habit.name === 'string' ? habit.name.trim() : '';
+    if (!name) return null;
+    const normalized = { ...habit };
+    normalized.id = normalized.id || generateId();
+    normalized.name = name;
+    normalized.color = typeof normalized.color === 'string' ? normalized.color : '#4dd0e1';
+    normalized.notes = typeof normalized.notes === 'string' ? normalized.notes : '';
+    normalized.reminderEnabled = Boolean(normalized.reminderEnabled);
+    normalized.reminderTime = normalized.reminderTime || null;
+    normalized.reminderDays = Array.isArray(normalized.reminderDays) ? normalized.reminderDays.filter(d => Number.isInteger(d)) : [];
+    const safeEntries = {};
+    const rawEntries = normalized.entries && typeof normalized.entries === 'object' ? normalized.entries : {};
+    Object.entries(rawEntries).forEach(([date, entry]) => {
+      if (typeof date !== 'string' || !entry || typeof entry !== 'object') return;
+      const mark = MARK_SEQUENCE.includes(entry.mark) ? entry.mark : 'NONE';
+      safeEntries[date] = {
+        date,
+        mark,
+        reason: typeof entry.reason === 'string' ? entry.reason : ''
+      };
+    });
+    normalized.entries = safeEntries;
+    normalized.currentStreak = Number(normalized.currentStreak) || 0;
+    normalized.bestStreak = Number(normalized.bestStreak) || 0;
+    normalized.lastCelebration = Number(normalized.lastCelebration) || 0;
+    normalized.created = normalized.created || formatDate(new Date());
+    return normalized;
   }
 
   function migrateLegacyData(legacy) {
@@ -1718,8 +1768,18 @@
     const reader = new FileReader();
     reader.onload = (e) => {
       try {
-        const data = JSON.parse(e.target.result);
-        appState = normalizeState(data);
+        const data = safeParseJSON(e.target.result, null);
+        if (!data || typeof data !== 'object') {
+          throw new Error('Invalid JSON structure.');
+        }
+        if (!Array.isArray(data.habits)) {
+          throw new Error('Import must include a habits array.');
+        }
+        const normalized = normalizeState(data);
+        if (!Array.isArray(normalized.habits)) {
+          throw new Error('Import data is missing habits.');
+        }
+        appState = normalized;
         persistAndRefresh();
         scheduleAllReminders();
         showToast('Import successful', 'Your data has been loaded.');

--- a/meal-trackerv.2.html
+++ b/meal-trackerv.2.html
@@ -2164,6 +2164,81 @@
 
     const KCAL_PER_KG = 7700;
     const MS_PER_DAY = 86400000;
+    const STORAGE_KEYS = {
+      profile: 'lifeos:meals:profile',
+      targets: 'lifeos:meals:targets',
+      presets: 'lifeos:meals:presets',
+      weights: 'lifeos:meals:weights'
+    };
+    const LEGACY_STORAGE_KEYS = {
+      profile: 'profile',
+      targets: 'targets',
+      presets: 'presets',
+      weights: 'weights'
+    };
+
+    function safeParseJSON(raw, fallback, keyForQuarantine = '') {
+      if (typeof raw !== 'string') return fallback;
+      try {
+        return JSON.parse(raw);
+      } catch (error) {
+        console.warn(`Invalid JSON in storage key "${keyForQuarantine}"`, error);
+        if (keyForQuarantine) {
+          localStorage.setItem(`${keyForQuarantine}__corrupt__${Date.now()}`, raw);
+          localStorage.removeItem(keyForQuarantine);
+        }
+        return fallback;
+      }
+    }
+
+    function safeGetStorage(key, fallback = null) {
+      const raw = localStorage.getItem(key);
+      return raw ? safeParseJSON(raw, fallback, key) : fallback;
+    }
+
+    function safeSetStorage(key, value) {
+      localStorage.setItem(key, JSON.stringify(value));
+    }
+
+    function mealKey(date) { return `lifeos:meals:entries:${date}`; }
+    function waterKey(date) { return `lifeos:meals:water:${date}`; }
+
+    function migrateStorageKeys() {
+      Object.entries(STORAGE_KEYS).forEach(([name, nextKey]) => {
+        if (localStorage.getItem(nextKey) !== null) return;
+        const legacyKey = LEGACY_STORAGE_KEYS[name];
+        const legacyRaw = localStorage.getItem(legacyKey);
+        if (legacyRaw === null) return;
+        const parsed = safeParseJSON(legacyRaw, null, legacyKey);
+        if (parsed !== null) safeSetStorage(nextKey, parsed);
+        localStorage.removeItem(legacyKey);
+      });
+      const keysToMigrate = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (!key) continue;
+        if (key.startsWith('meals_')) keysToMigrate.push(key);
+        if (key.startsWith('water_')) keysToMigrate.push(key);
+      }
+      keysToMigrate.forEach((legacyKey) => {
+        const isMeals = legacyKey.startsWith('meals_');
+        const date = legacyKey.slice(isMeals ? 6 : 6);
+        const targetKey = isMeals ? mealKey(date) : waterKey(date);
+        if (localStorage.getItem(targetKey) !== null) return;
+        const raw = localStorage.getItem(legacyKey);
+        if (raw === null) return;
+        if (isMeals) {
+          const parsed = safeParseJSON(raw, [], legacyKey);
+          safeSetStorage(targetKey, parsed);
+        } else {
+          const n = Number(raw);
+          localStorage.setItem(targetKey, String(Number.isFinite(n) ? n : 0));
+        }
+        localStorage.removeItem(legacyKey);
+      });
+    }
+
+    migrateStorageKeys();
 
     function navTo(page) {
       document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));
@@ -2235,30 +2310,30 @@
     }
 
     function getProfile() {
-      const raw = localStorage.getItem('profile');
-      return raw ? { ...defaultProfile, ...JSON.parse(raw) } : { ...defaultProfile };
+      const stored = safeGetStorage(STORAGE_KEYS.profile, {});
+      return { ...defaultProfile, ...(stored && typeof stored === 'object' ? stored : {}) };
     }
 
     function saveProfile(profile) {
-      localStorage.setItem('profile', JSON.stringify(profile));
+      safeSetStorage(STORAGE_KEYS.profile, profile);
     }
 
     function getTargets() {
-      const raw = localStorage.getItem('targets');
-      return raw ? { ...defaultTargets, ...JSON.parse(raw) } : { ...defaultTargets };
+      const stored = safeGetStorage(STORAGE_KEYS.targets, {});
+      return { ...defaultTargets, ...(stored && typeof stored === 'object' ? stored : {}) };
     }
 
     function saveTargets(targets) {
-      localStorage.setItem('targets', JSON.stringify(targets));
+      safeSetStorage(STORAGE_KEYS.targets, targets);
     }
 
     function getPresets() {
-      const raw = localStorage.getItem('presets');
-      return raw ? JSON.parse(raw) : defaultPresets;
+      const parsed = safeGetStorage(STORAGE_KEYS.presets, defaultPresets);
+      return Array.isArray(parsed) ? parsed : defaultPresets;
     }
 
     function savePresetData(presets) {
-      localStorage.setItem('presets', JSON.stringify(presets));
+      safeSetStorage(STORAGE_KEYS.presets, presets);
     }
 
     function currentTimeValue() {
@@ -2516,20 +2591,21 @@
     }
 
     function getMeals(date) {
-      const raw = localStorage.getItem('meals_' + date);
-      return raw ? JSON.parse(raw) : [];
+      const parsed = safeGetStorage(mealKey(date), []);
+      if (!Array.isArray(parsed)) return [];
+      return parsed.map(normalizeMealEntry).filter(Boolean);
     }
 
     function saveMeals(date, meals) {
-      localStorage.setItem('meals_' + date, JSON.stringify(meals));
+      safeSetStorage(mealKey(date), meals);
     }
 
     function getLoggedMealDates() {
       const dates = [];
       for (let i = 0; i < localStorage.length; i++) {
         const key = localStorage.key(i);
-        if (key && key.startsWith('meals_')) {
-          dates.push(key.slice(6));
+        if (key && key.startsWith('lifeos:meals:entries:')) {
+          dates.push(key.slice('lifeos:meals:entries:'.length));
         }
       }
       dates.sort((a, b) => new Date(b) - new Date(a));
@@ -2537,23 +2613,51 @@
     }
 
     function getWater(date) {
-      const raw = localStorage.getItem('water_' + date);
+      const raw = localStorage.getItem(waterKey(date));
       return raw ? Number(raw) : 0;
     }
 
     function saveWater(date, amount) {
-      localStorage.setItem('water_' + date, String(amount));
+      localStorage.setItem(waterKey(date), String(amount));
     }
 
     function getWeights() {
-      const raw = localStorage.getItem('weights');
-      const data = raw ? JSON.parse(raw) : [];
-      data.sort((a, b) => new Date(a.date) - new Date(b.date));
-      return data;
+      const data = safeGetStorage(STORAGE_KEYS.weights, []);
+      if (!Array.isArray(data)) return [];
+      const normalized = data.map(normalizeWeightEntry).filter(Boolean);
+      normalized.sort((a, b) => new Date(a.date) - new Date(b.date));
+      return normalized;
+    }
+
+    function normalizeMealEntry(entry) {
+      if (!entry || typeof entry !== 'object') return null;
+      const calories = Number(entry.calories);
+      const name = typeof entry.name === 'string' ? entry.name.trim() : '';
+      if (!name || Number.isNaN(calories)) return null;
+      return {
+        id: entry.id || `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        name,
+        calories: Math.max(0, calories),
+        ingredients: typeof entry.ingredients === 'string' ? entry.ingredients : '',
+        protein: Number(entry.protein) || 0,
+        carbs: Number(entry.carbs) || 0,
+        fat: Number(entry.fat) || 0,
+        type: typeof entry.type === 'string' ? entry.type : inferMealType(entry.time),
+        time: typeof entry.time === 'string' ? entry.time : currentTimeValue(),
+        date: typeof entry.date === 'string' ? entry.date : dateInput.value
+      };
+    }
+
+    function normalizeWeightEntry(entry) {
+      if (!entry || typeof entry !== 'object') return null;
+      const weight = Number(entry.weight);
+      const date = typeof entry.date === 'string' ? entry.date : '';
+      if (!date || !Number.isFinite(weight) || weight <= 0) return null;
+      return { date, weight };
     }
 
     function saveWeights(entries) {
-      localStorage.setItem('weights', JSON.stringify(entries));
+      safeSetStorage(STORAGE_KEYS.weights, entries);
     }
 
     function formatNumber(value, decimals = 0) {
@@ -3287,7 +3391,7 @@
           if (meals.length) {
             saveMeals(selectedDate, meals);
           } else {
-            localStorage.removeItem('meals_' + selectedDate);
+            localStorage.removeItem(mealKey(selectedDate));
           }
           updateHistory();
           refreshCurrentDayIfMatched(selectedDate);


### PR DESCRIPTION
### Motivation
- Prevent startup crashes and runtime errors caused by raw `JSON.parse` on corrupted localStorage and by assumptions about persisted shapes across pages.
- Ensure UI previews are responsive to live input (no stale projections) and make Kanban WIP limits visible, editable and enforced.
- Harden imports, drag/drop, and rendering so malformed data never replaces app state or throws uncaught exceptions.
- Namespace storage keys per page to avoid cross-page collisions and provide a one-time migration from legacy keys.

### Description
- Added robust storage utilities (`safeParseJSON`, `safeGetStorage`, `safeSetStorage`) and one-time migration logic to all four pages (`getyourshit_together.html`, `KanbanBoard.html`, `meal-trackerv.2.html`, `habit-tracker-enhanced.html`) and switched to namespaced keys like `lifeos:kanban:tasks` and `lifeos:meals:entries:<date>`.
- Introduced normalization helpers (`normalizeTask`, `normalizeHabit`, `normalizeMeal` / `normalizeMealEntry`, `normalizeWeightEntry`, `normalizeWipLimits`) and applied them to loaded and imported data so rendering never assumes missing properties.
- Fixed projection staleness by computing target projections from current form inputs (`getDraftTargetsFromForm`) while typing and using persisted targets only for initial load or explicit save.
- Wired Kanban WIP UI completely: added missing DOM inputs `limit-todo`, `limit-doing`, `limit-done`, persisted limits, normalized values, and enforced limits on add/move with non-blocking warnings and safe drag/drop guards for invalid payloads.
- Hardened habit import/backup paths to parse safely, validate structure, normalize entries, quarantine corrupted JSON to `key__corrupt__<ts>`, and reject unusable imports with clear messages.
- Centralized per-day meal keys and migrated legacy `meals_`/`water_` keys to namespaced keys; added defensive meal/weight normalization when loading.
- Added a small dev self-test hook (`window.lifeOsSelfTest()`) to run quick client-side sanity checks.

### Testing
- Ran static/audit checks to confirm helpers were added and DOM wiring exists with quick scripts: `rg` and small `python` checks (presence of `safeParseJSON` in files and WIP input ids), which succeeded.
- Verified JSON parse replacements and migration code by scanning occurrences of `JSON.parse` and ensuring safe parsing wrappers are present; scan succeeded.
- Launched a local HTTP server and captured a browser screenshot of the Kanban page using Playwright to verify WIP inputs render correctly; the automated screenshot run succeeded and image was produced (`artifacts/kanban-wip-limits.png`).
- Executed repository checks and commit: `git diff --stat` and `git commit` completed successfully and the patch affecting four files was recorded.
- Note: a lightweight in-browser dev check is available via `window.lifeOsSelfTest()` to validate normalized state at runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992d9d7fb0c83308da44c3135786440)